### PR TITLE
fix: request address body contains space or line seperator

### DIFF
--- a/internal/detection/thirdparty.go
+++ b/internal/detection/thirdparty.go
@@ -118,7 +118,7 @@ func (d *ThirdPartyAddressDetector) requestAddress(parentCtx context.Context) (s
 	}
 
 	d.logger.Debug("use body as address directly", "body", body)
-	return string(body), nil
+	return strings.TrimSpace(string(body)), nil
 }
 
 func (d *ThirdPartyAddressDetector) extractIP(parentCtx context.Context, response []byte, jsonpath string) (string, error) {


### PR DESCRIPTION
the behavior is fixed in higher go version, but we should do the trim too to fit lower go version.